### PR TITLE
install configparse for python2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 prometheus-client==0.12.0
+configparser==5.2.0


### PR DESCRIPTION
## Description of the change

for python2.7 have no package name configparse